### PR TITLE
split ink text handling into multiple functions

### DIFF
--- a/src/pages/info/controls.pug
+++ b/src/pages/info/controls.pug
@@ -2,7 +2,7 @@
 - var month = (now.getMonth()+1).toString().padStart(2, '0');
 - var day = now.getDate().toString().padStart(2, '0');
 - var date = `${now.getFullYear()}/${month}/${day}`;
-- var version = "0.11.0-beta";
+- var version = "0.12.0-beta";
 
 #info-tab-body.controls-tab-body(hidden)
     h2= `binksi -- ${version} (${date})`

--- a/src/scripts/playback.js
+++ b/src/scripts/playback.js
@@ -622,8 +622,11 @@ class BipsiPlayback extends EventTarget {
         return {}
     }
 
-    // A handler can return true to prevent the next handlers from running
-    paragraphHandlers = [
+    // paragraphHandlers is static so that plugins can easily modify it without waiting for the playback to be instanciated.
+    // "this" in a handler will be set to the playback instance.
+    // A handler can return true to prevent the next handlers from running.
+    // If no handler marks the paragraph as handled (by returning true), the text will be displayed with the context sayStyle.
+    static paragraphHandlers = [
         async function handleSpawnAt({paragraphText}){
             const matchSpawn = paragraphText.match(/SPAWN_AT\(([^),\s]*)([\s]*,[\s]*([^)]*)*)*\)/)
             if ( matchSpawn ){
@@ -674,7 +677,7 @@ class BipsiPlayback extends EventTarget {
     ];
 
     async runParagraphHandlers(context) {
-        for (const h of this.paragraphHandlers) {
+        for (const h of BipsiPlayback.paragraphHandlers) {
             if (await h.call(this, context) === true) return true;
         }
     }


### PR DESCRIPTION
This MR splits the paragraph handling code from continueStory() into multiple small functions.
Handlers are stored in the `paragraphHandlers` array so that it is easy to add/remove handlers from plugins.
Handlers can return `true` to tell the paragraph is handled and skip the rest of the handlers (this mimics the previous if-elseif-elseif-else code).

Things I'm not happy with: 
- [SOLVED] ~~I haven't yet moved the say-style/portrait code to that handlers array because of the `defaultSayStyle` variable (passing it to `runParagraphHandlers()` feels clunky)~~ 
    - Passing the `defaultSayStyle` felt wrong but passing the sayStyle that will be used so that handlers can modify it feels good. Now handlers receive a `context` argument containing the sayStyle, tags & paragraphText.
- [SOLVED] ~~The array is an instance property so `PLAYBACK.paragraphHandlers` is only accessible after start. Not a big deal but it could be better.~~
    - I've made `paragraphHandlers` static (i.e. a class property) so it's available as `BipsiPlayback.paragraphHandlers` even before the playback object is instantiated.
