### PR TITLE
Post sync fixes

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,1 +1,0 @@
-call pug --pretty -o dist --basedir src -- src/index.pug 

--- a/publish-beta.cmd
+++ b/publish-beta.cmd
@@ -1,3 +1,0 @@
-call build
-call copy .\dist\index.html .\dist\beta.html
-call neocities upload -d bipsi .\dist\beta.html

--- a/src/scripts/playback.js
+++ b/src/scripts/playback.js
@@ -655,7 +655,8 @@ class BipsiPlayback extends EventTarget {
         },
         async function handleTitleTag({paragraphText, tags}) {
             if(tags.includes("TITLE")){
-                await this.title(paragraphText);
+                const [, background] = this.getActivePalette().colors;
+                await this.say(paragraphText, { anchorY: .5, backgroundColor: background });
                 return true;
             }
         },


### PR DESCRIPTION
- removed specific bipsi build scripts
- fixed # TITLE  tag which was broken by the latest bipsi update (`title()` method was removed)